### PR TITLE
Clear presents when going to play schema to remove old present data

### DIFF
--- a/Main.elm
+++ b/Main.elm
@@ -128,7 +128,7 @@ update msg model =
             { model | state = Players }
 
         PlaySchema ->
-            { model | state = Schema }
+            { model | state = Schema, present = [] }
 
         PlayerAdded ->
             { model


### PR DESCRIPTION
If you are going to `Play Schema` to set the presents for the the match and then go again the the `Play Schema` screen (by hitting cancel or play! and then play schema again). Then the previous presents are still set in the `presents` property. But are not reflected in the view. (The checkboxes are not checked).

The easiest way to fix this (for now) would be to clear the `presents` property while going to the `Play Schema` state. At least now the presents property and the view are telling the same story.

A better solution would be to set the checked state based on the model. Then you are certain than the checkboxes has the proper checked value and are not based on the behavior of the browser/view. For that we need to push the presents data from the model all the way from the `view` to the `presentToday` function.

I did not go for that solution because it is arguable if the `presents` property should even exists in the main model. It looks like it is constructed in `State.Schema` and only used in `State.GameUnderway`. Also the data in presents like `totalPlayTimeInMinutes` and `timesKept` might be hard to keep in sink. But that depends on what you intent to do with it. I am not fully aware of all the context but maybe it is worthwhile to move presents to State.GameUnderway.

In the mean time this will reset the presents and make the view and data tell the same story (bit cheaty)